### PR TITLE
LEELOO-166: Upstream Errors from Sentry logging endpoint

### DIFF
--- a/lib/task_bunny_sentry.ex
+++ b/lib/task_bunny_sentry.ex
@@ -3,32 +3,36 @@ defmodule TaskBunnySentry do
   A TaskBunny failure backend that reports to Sentry.
   """
   use TaskBunny.FailureBackend
-
+  require Logger
   alias TaskBunny.JobError
 
-  @type task :: {:ok, Task.t} | :error | :excluded | :ignored
+  @type task :: {:ok, Task.t()} | :error | :excluded | :ignored
 
-  @spec report_job_error(error :: JobError.t, opts :: [extra: list(atom)]) :: task
+  @spec report_job_error(error :: JobError.t(), opts :: [extra: list(atom)]) :: task
   def report_job_error(error = %JobError{error_type: :exception}, opts = [extra: _]) do
     report_error(error.exception, error.stacktrace, error, opts)
   end
 
-  @spec report_job_error(error :: JobError.t) :: task
+  @spec report_job_error(error :: JobError.t()) :: task
   def report_job_error(error = %JobError{error_type: :exception}) do
     report_error(error.exception, error.stacktrace, error)
   end
+
   def report_job_error(error = %JobError{error_type: :exit}) do
     %TaskBunnyError{message: "Unexpected exit signal"}
     |> report_error(error.stacktrace, error)
   end
+
   def report_job_error(error = %JobError{error_type: :return_value}) do
     %TaskBunnyError{message: "Unexpected return value"}
     |> report_error(original_stacktrace(Process.info(self(), :current_stacktrace)), error)
   end
+
   def report_job_error(error = %JobError{error_type: :timeout}) do
     %TaskBunnyError{message: "Timeout error"}
     |> report_error(original_stacktrace(Process.info(self(), :current_stacktrace)), error)
   end
+
   def report_job_error(error = %JobError{}) do
     %TaskBunnyError{message: "Unknown error"}
     |> report_error(original_stacktrace(Process.info(self(), :current_stacktrace)), error)
@@ -42,17 +46,29 @@ defmodule TaskBunnySentry do
   end
 
   defp report_error(naked_exception, stacktrace, wrapped_error, opts \\ []) do
-    extra = naked_exception
-    |> Map.take(Keyword.get(opts, :extra, []))
-    |> Map.merge(%{
-      meta: inspect(wrapped_error.meta),
-      job: wrapped_error.job,
-      job_payload: wrapped_error.payload,
-      pid: inspect(wrapped_error.pid),
-      exit: wrapped_error.reason,
-      return_value: inspect(wrapped_error.return_value)
-    })
+    extra =
+      naked_exception
+      |> Map.take(Keyword.get(opts, :extra, []))
+      |> Map.merge(%{
+        meta: inspect(wrapped_error.meta),
+        job: wrapped_error.job,
+        job_payload: wrapped_error.payload,
+        pid: inspect(wrapped_error.pid),
+        exit: wrapped_error.reason,
+        return_value: inspect(wrapped_error.return_value)
+      })
 
-    Sentry.capture_exception(naked_exception, [stacktrace: stacktrace, extra: extra])
+    Sentry.capture_exception(naked_exception, stacktrace: stacktrace, extra: extra)
+    |> case do
+      {:ok, _event_id} = result ->
+        result
+
+      {:error, reason} ->
+        Logger.error("#{__MODULE__}: Could not send error to upstream.
+          JobError: #{inspect(naked_exception)} : #{inspect(extra)}
+          Reason: #{inspect(reason)}")
+
+        :error
+    end
   end
 end

--- a/test/task_bunny_sentry_test.exs
+++ b/test/task_bunny_sentry_test.exs
@@ -128,7 +128,7 @@ defmodule TaskBunnySentryTest do
       assert Regex.match?(~r/^[a-f0-9]{32}$/, event_id)
     end
 
-    test "handle the invlid return error" do
+    test "handle the invalid return error" do
       error = JobError.handle_return_value(@job, @payload, {:error, :error_detail})
 
       expect(SentryMock, :send_event, fn %Sentry.Event{event_id: id} = event, _ ->
@@ -149,6 +149,27 @@ defmodule TaskBunnySentryTest do
       {:ok, event_id} = Task.await(task)
 
       assert Regex.match?(~r/^[a-f0-9]{32}$/, event_id)
+    end
+
+    test "handle failure of upstream timeout" do
+      error = JobError.handle_return_value(@job, @payload, {:error, :error_detail})
+
+      expect(SentryMock, :send_event, fn %Sentry.Event{event_id: id} = event, _ ->
+        assert event.exception == [%{module: nil, type: TaskBunnyError, value: "Unexpected return value"}]
+        assert event.extra == %{
+          exit: nil,
+          job: TaskBunnySentry.TestJob,
+          job_payload: %{"test" => true},
+          meta: "%{}",
+          pid: "nil",
+          return_value: "{:error, :error_detail}"
+        }
+
+        {:error, :generic_timeout_error}
+      end)
+
+      assert :error = TaskBunnySentry.report_job_error(error)
+
     end
   end
 end


### PR DESCRIPTION
ref: [LEELOO-166](https://homepolish.atlassian.net/browse/LEELOO-166)

The Sentry Logger has the potential of failing and returning an error tuple.
In order to match the specs provided by the `FailureBackend` behavior, we will catch generic error tuples, log the error internally, and return the expected `:error` atom. 

In order to truly close this issue, multipass needs its `mix.lock` updated.

Edit:
May be worth looking into retry logic as well as adding `catch` and `rescue` using the same logic as the actual worker.